### PR TITLE
Hyperlink DOIs to preferred resolver

### DIFF
--- a/dsl2html.py
+++ b/dsl2html.py
@@ -72,7 +72,7 @@ for dsl in glob.glob("*.dsl") + glob.glob("*/*.dsl") + glob.glob("*/*/*.dsl"):
 				paperX = lines[i].strip()[3:-4]
 				lines[i] = ''
 			elif lines[i].strip().startswith('<doi>'):
-				paperFull = 'http://dx.doi.org/'+lines[i].strip()[5:-6]
+				paperFull = 'https://doi.org/'+lines[i].strip()[5:-6]
 				lines[i] = ''
 			elif lines[i].strip().startswith('<uri'):
 				if lines[i].strip().startswith('<uri>'):


### PR DESCRIPTION
Hello :-)

The DOI foundation recommends [this new resolver](https://www.doi.org/doi_handbook/3_Resolution.html#3.8). It may be a bit ironic that they would change the URL of their service, but it's now [encrypted](https://www.ssllabs.com/ssltest/analyze.html?d=doi.org). Because the old `dx` subdomain is being redirected, there is no urgent need to do anything.

However, I'd hereby like to suggest to follow the new recommendation by applying this update to the code that generates new DOI links.

Cheers!